### PR TITLE
Add some unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ statrs = "0.10"
 [dev-dependencies]
 approx = "0.3.1"
 openblas-src = "0.7"
+pyo3 = "0.8"
+numpy = "0.7.0"
+num-traits = "0.2"


### PR DESCRIPTION
I just added some random test and expm is already failing:
```
running 8 tests
test tests::exp_of_random_matrix ... FAILED
test tests::exp_of_doubled_unit ... FAILED
test tests::verify_pade_13 ... ok
test tests::verify_pade_3 ... ok
test tests::verify_pade_5 ... ok
test tests::verify_pade_7 ... ok
test tests::verify_pade_9 ... ok
test tests::exp_of_unit ... ok

failures:

---- tests::exp_of_random_matrix stdout ----
thread 'tests::exp_of_random_matrix' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `7`', src/lib.rs:243:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

---- tests::exp_of_doubled_unit stdout ----
thread 'tests::exp_of_doubled_unit' panicked at 'assertion failed: `(left == right)`
  left: `4`,
 right: `7`', src/lib.rs:243:9


failures:
    tests::exp_of_doubled_unit
    tests::exp_of_random_matrix

test result: FAILED. 6 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out

```

It might be beneficial to extend the test coverage further